### PR TITLE
Fix the `@App.Settings.TimeZoneName` value

### DIFF
--- a/src/Seq.Mail/BuiltIns/MailAppNameResolver.cs
+++ b/src/Seq.Mail/BuiltIns/MailAppNameResolver.cs
@@ -15,9 +15,11 @@ class MailAppNameResolver: NameResolver
     {
         _host = host;
 
-        var settings = new Dictionary<string, string>(app.Settings)
+        // It turned out that passing all of the "real" settings here was a questionable idea,
+        // because they're not consistently cased (e.g. at runtime they're uppercase, but this
+        // isn't guaranteed).
+        var settings = new Dictionary<string, string>
         {
-            // Override the "real" settings with their defaults
             [nameof(MailApp.TimeZoneName)] = timeZoneName,
             [nameof(MailApp.DateTimeFormat)] = dateFormat
         };

--- a/src/Seq.Syntax/Expressions/Compilation/Linq/LinqExpressionCompiler.cs
+++ b/src/Seq.Syntax/Expressions/Compilation/Linq/LinqExpressionCompiler.cs
@@ -191,7 +191,7 @@ class LinqExpressionCompiler : SerilogExpressionTransformer<ExpressionBody>
     protected override ExpressionBody Transform(AccessorExpression spx)
     {
         var receiver = Transform(spx.Receiver);
-        return LX.Call(TryGetStructurePropertyValueMethod, LX.Constant(StringComparison.OrdinalIgnoreCase), receiver, LX.Constant(spx.MemberName, typeof(string)));
+        return LX.Call(TryGetStructurePropertyValueMethod, LX.Constant(StringComparison.Ordinal), receiver, LX.Constant(spx.MemberName, typeof(string)));
     }
 
     protected override ExpressionBody Transform(Ast.ConstantExpression cx)

--- a/test/Seq.Syntax.Tests/Cases/expression-evaluation-cases.asv
+++ b/test/Seq.Syntax.Tests/Cases/expression-evaluation-cases.asv
@@ -24,6 +24,10 @@ false                                ⇶ false
 {a: 1, ..{b: 2}, b: undefined()}     ⇶ {a: 1}
 {a: 1, ..{a: undefined()}}           ⇶ {a: 1}
 {..{a: 1}, ..{b: 2, c: 3}}           ⇶ {a: 1, b: 2, c: 3}
+{a: 1}['a']                          ⇶ 1
+{a: 1}['A']                          ⇶ undefined()
+ElementAt({a: 1}, 'A')               ⇶ undefined()
+ElementAt({a: 1}, 'A') ci            ⇶ 1
 
 // Strings
 ''                                   ⇶ ''


### PR DESCRIPTION
Turns out we initially treated structure access as case-insensitive, and this masked a difference between the setting name passed from Seq, and the one we were using.