### PR TITLE
Revert "Package updates, use Serilog built-ins for trace and span ids"

### DIFF
--- a/src/Seq.App.Mail.Microsoft365/Seq.App.Mail.Microsoft365.csproj
+++ b/src/Seq.App.Mail.Microsoft365/Seq.App.Mail.Microsoft365.csproj
@@ -24,9 +24,9 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Seq.Apps" Version="2023.4.0" />
-    <PackageReference Include="Azure.Identity" Version="1.10.4" />
-    <PackageReference Include="Microsoft.Graph" Version="5.36.0" />
+    <PackageReference Include="Seq.Apps" Version="2021.4.0" />
+    <PackageReference Include="Azure.Identity" Version="1.10.0" />
+    <PackageReference Include="Microsoft.Graph" Version="5.23.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Seq.App.Mail.Smtp/Seq.App.Mail.Smtp.csproj
+++ b/src/Seq.App.Mail.Smtp/Seq.App.Mail.Smtp.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Seq.Apps" Version="2023.4.0" />
+    <PackageReference Include="Seq.Apps" Version="2021.4.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Seq.Mail/Seq.Mail.csproj
+++ b/src/Seq.Mail/Seq.Mail.csproj
@@ -23,9 +23,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="mailkit" Version="4.3.0" />
+    <PackageReference Include="mailkit" Version="4.1.0" />
     <PackageReference Include="Superpower" Version="3.0.0" />
-    <PackageReference Include="Seq.Apps" Version="2023.4.0" />
+    <PackageReference Include="Seq.Apps" Version="2021.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Seq.Syntax/BuiltIns/SeqBuiltInPropertyNameResolver.cs
+++ b/src/Seq.Syntax/BuiltIns/SeqBuiltInPropertyNameResolver.cs
@@ -17,10 +17,9 @@ class SeqBuiltInPropertyNameResolver: NameResolver
             "EventType" => "@i",
             "Exception" => "@x",
             "Id" => "@p['@seqid']",
-            "TraceId" => "@tr",
-            "SpanId" => "@sp",
+            "TraceId" or "@tr" => "@p['@tr']",
+            "SpanId" or "@sp" => "@p['@sp']",
             "Resource" or "@ra" => "@p['@ra']",
-            "ParentId" or "@ps" => "@p['@ps']",
             "Arrived" or "Document" or "Data" => "undefined()",
             _ => null
         };

--- a/src/Seq.Syntax/Expressions/BuiltInProperty.cs
+++ b/src/Seq.Syntax/Expressions/BuiltInProperty.cs
@@ -25,6 +25,4 @@ static class BuiltInProperty
     public const string Properties = "p";
     public const string Renderings = "r";
     public const string EventId = "i";
-    public const string TraceId = "tr";
-    public const string SpanId = "sp";
 }

--- a/src/Seq.Syntax/Expressions/Compilation/Linq/LinqExpressionCompiler.cs
+++ b/src/Seq.Syntax/Expressions/Compilation/Linq/LinqExpressionCompiler.cs
@@ -219,8 +219,6 @@ class LinqExpressionCompiler : SerilogExpressionTransformer<ExpressionBody>
                         null)),
                 BuiltInProperty.Renderings => Splice(context => Intrinsics.GetRenderings(context.LogEvent, formatProvider)),
                 BuiltInProperty.EventId => Splice(context => Intrinsics.GetEventId(context.LogEvent)),
-                BuiltInProperty.TraceId => Splice(context => new ScalarValue(context.LogEvent.TraceId)),
-                BuiltInProperty.SpanId => Splice(context => new ScalarValue(context.LogEvent.SpanId)),
                 var alias when _nameResolver.TryResolveBuiltInPropertyName(alias, out var target) =>
                     Transform(ExpressionCompiler.Translate(new ExpressionParser().Parse(target))),
                 _ => LX.Constant(null, typeof(LogEventPropertyValue))

--- a/src/Seq.Syntax/Seq.Syntax.csproj
+++ b/src/Seq.Syntax/Seq.Syntax.csproj
@@ -21,7 +21,7 @@
     <ItemGroup>
         <None Include="../../asset/seq-syntax.png" Pack="true" Visible="false" PackagePath="" />
         <PackageReference Include="Superpower" Version="3.0.0" />
-        <PackageReference Include="Serilog" Version="3.1.1" />
+        <PackageReference Include="Serilog" Version="3.0.1" />
     </ItemGroup>
     
 </Project>

--- a/test/Seq.Mail.Tests/Seq.Mail.Tests.csproj
+++ b/test/Seq.Mail.Tests/Seq.Mail.Tests.csproj
@@ -5,13 +5,13 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="Serilog.Formatting.Compact" Version="2.0.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Seq.App.Mail.Microsoft365\Seq.App.Mail.Microsoft365.csproj" />

--- a/test/Seq.Syntax.Tests/Seq.Syntax.Tests.csproj
+++ b/test/Seq.Syntax.Tests/Seq.Syntax.Tests.csproj
@@ -5,13 +5,13 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="xunit" Version="2.6.2" />
-        <PackageReference Include="Serilog.Formatting.Compact" Version="2.0.0" />
+        <PackageReference Include="xunit" Version="2.5.0" />
+        <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\src\Seq.Syntax\Seq.Syntax.csproj" />


### PR DESCRIPTION
Reverts datalust/seq-app-mail#16, needs a `seqcli` update before we can ship this:

![image](https://github.com/datalust/seq-app-mail/assets/342712/17ec2742-c1a8-4e42-b26d-cf88a025fcc0)
