### PR TITLE
Allow short format specifiers wherever levels appear

### DIFF
--- a/src/Seq.Mail/BuiltIns/MailAppBuiltInFunctions.cs
+++ b/src/Seq.Mail/BuiltIns/MailAppBuiltInFunctions.cs
@@ -11,23 +11,6 @@ namespace Seq.Mail.BuiltIns;
 
 public static class MailAppBuiltInFunctions
 {
-    public static LogEventPropertyValue? ToString(LogEventPropertyValue? value, LogEventPropertyValue? format)
-    {
-        if (value is not ScalarValue { Value: {} sv } ||
-            format is not null and not ScalarValue { Value: string })
-        {
-            return null;
-        }
-
-        if (sv is IFormattable formattable && format is ScalarValue { Value: string f })
-        {
-            // Culture may end up having to be selectable.
-            return new ScalarValue(formattable.ToString(f, CultureInfo.InvariantCulture));
-        }
-
-        return new ScalarValue(sv.ToString());
-    }
-        
     public static LogEventPropertyValue? UriEncode(LogEventPropertyValue? value)
     {
         if (Coerce.String(value, out var s))

--- a/src/Seq.Syntax/BuiltIns/SeqBuiltInPropertyNameResolver.cs
+++ b/src/Seq.Syntax/BuiltIns/SeqBuiltInPropertyNameResolver.cs
@@ -1,5 +1,9 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Reflection;
 using Seq.Syntax.Expressions;
+using Serilog.Events;
 
 namespace Seq.Syntax.BuiltIns;
 
@@ -9,7 +13,7 @@ class SeqBuiltInPropertyNameResolver: NameResolver
     {
         target = alias switch
         {
-            "Properties" => "{..@p, @seqid: undefined(), @i: undefined(), @tr: undefined(), @sp: undefined(), @ra: undefined()}",
+            "Properties" => "{..@p, @seqid: undefined(), @i: undefined(), @tr: undefined(), @sp: undefined(), @ra: undefined(), @st: undefined(), @ps: undefined(), @sa: undefined()}",
             "Timestamp" => "@t",
             "Level" => "@l",
             "Message" => "@m",
@@ -17,13 +21,52 @@ class SeqBuiltInPropertyNameResolver: NameResolver
             "EventType" => "@i",
             "Exception" => "@x",
             "Id" => "@p['@seqid']",
-            "TraceId" or "@tr" => "@p['@tr']",
-            "SpanId" or "@sp" => "@p['@sp']",
-            "Resource" or "@ra" => "@p['@ra']",
+            "TraceId" or "tr" => "@p['@tr']",
+            "SpanId" or "sp" => "@p['@sp']",
+            "Resource" or "ra" => "@p['@ra']",
+            "Start" or "st" => "@p['@st']",
+            "ParentId" or "ps" => "@p['@ps']",
+            "Scope" or "sa" => "@p['@sa']",
+            "Elapsed" => "_Elapsed(@st, @t)",
             "Arrived" or "Document" or "Data" => "undefined()",
             _ => null
         };
 
         return target != null;
+    }
+
+    public override bool TryResolveFunctionName(string name, [NotNullWhen(true)] out MethodInfo? implementation)
+    {
+        if (name == nameof(_Elapsed))
+        {
+            implementation = typeof(SeqBuiltInPropertyNameResolver).GetMethod(name)!;
+            return true;
+        }
+
+        implementation = null;
+        return false;
+    }
+    
+    public static LogEventPropertyValue? _Elapsed(LogEventPropertyValue? from, LogEventPropertyValue? to)
+    {
+        if (AsDateTimeOffset(from) is {} f && AsDateTimeOffset(to) is {} t)
+            return new ScalarValue(t - f);
+
+        return null;
+    }
+
+    static DateTimeOffset? AsDateTimeOffset(LogEventPropertyValue? value)
+    {
+        if (value is ScalarValue { Value: DateTime dt })
+            return dt;
+        
+        if (value is ScalarValue { Value: DateTimeOffset dto })
+            return dto;
+
+        if (value is ScalarValue { Value: string s } &&
+            DateTimeOffset.TryParseExact(s, "o", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed))
+            return parsed;
+
+        return null;
     }
 }

--- a/src/Seq.Syntax/Expressions/Runtime/RuntimeOperators.cs
+++ b/src/Seq.Syntax/Expressions/Runtime/RuntimeOperators.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Seq.Syntax.Expressions.Compilation.Linq;
+using Seq.Syntax.Templates.Rendering;
 using Serilog.Events;
 
 // ReSharper disable ForCanBeConvertedToForeach, InvertIf, MemberCanBePrivate.Global, UnusedMember.Global, InconsistentNaming, ReturnTypeCanBeNotNullable
@@ -501,16 +502,13 @@ static class RuntimeOperators
         {
             return null;
         }
-
-        string? toString;
-        if (sv.Value is IFormattable formattable)
+        
+        var toString = sv.Value switch
         {
-            toString = formattable.ToString(fmt, formatProvider);
-        }
-        else
-        {
-            toString = sv.Value.ToString();
-        }
+            LogEventLevel level => LevelRenderer.GetLevelMoniker(level, fmt),
+            IFormattable formattable => formattable.ToString(fmt, formatProvider),
+            _ => sv.Value.ToString()
+        };
 
         return new ScalarValue(toString);
     }

--- a/src/Seq.Syntax/Templates/Compilation/TemplateCompiler.cs
+++ b/src/Seq.Syntax/Templates/Compilation/TemplateCompiler.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Globalization;
 using System.Linq;
+using Seq.Syntax.BuiltIns;
 using Seq.Syntax.Expressions;
 using Seq.Syntax.Expressions.Ast;
 using Seq.Syntax.Expressions.Compilation;
@@ -32,7 +33,7 @@ static class TemplateCompiler
         return template switch
         {
             LiteralText text => new CompiledLiteralText(text.Text),
-            FormattedExpression { Expression: AmbientNameExpression { IsBuiltIn: true, PropertyName: BuiltInProperty.Level} } level =>
+            FormattedExpression { Expression: AmbientNameExpression { IsBuiltIn: true, PropertyName: BuiltInProperty.Level } } level =>
                 encoder.Wrap(new CompiledLevelToken(level.Format, level.Alignment)),
             FormattedExpression
             {

--- a/test/Seq.Mail.Tests/Seq.Mail.Tests.csproj
+++ b/test/Seq.Mail.Tests/Seq.Mail.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/test/Seq.Syntax.Tests/Cases/expression-evaluation-cases.asv
+++ b/test/Seq.Syntax.Tests/Cases/expression-evaluation-cases.asv
@@ -299,3 +299,6 @@ uriencode(null)                      ⇶ undefined()
 uriencode(undefined())               ⇶ undefined()
 uriencode('')                        ⇶ ''
 uriencode(' ')                       ⇶ '%20'
+
+tostring(@l, 'u3')                   ⇶ 'INF'
+tostring(@Elapsed)                   ⇶ '00:10:00'

--- a/test/Seq.Syntax.Tests/Cases/template-evaluation-cases.asv
+++ b/test/Seq.Syntax.Tests/Cases/template-evaluation-cases.asv
@@ -1,6 +1,7 @@
 Hello, {'world'}!                        ⇶ Hello, world!
 {@l}                                     ⇶ Information
 {@l:u3}                                  ⇶ INF
+{@Level:u3}                                  ⇶ INF
 Items are {[1, 2]}                       ⇶ Items are [1,2]
 Members are { {a: 1, 'b c': 2} }         ⇶ Members are {"a":1,"b c":2}
 {@p}                                     ⇶ {"Name":"nblumhardt"}

--- a/test/Seq.Syntax.Tests/Expressions/ExpressionEvaluationTests.cs
+++ b/test/Seq.Syntax.Tests/Expressions/ExpressionEvaluationTests.cs
@@ -26,6 +26,8 @@ public class ExpressionEvaluationTests
                 new LogEventProperty("Id", new ScalarValue(42)),
                 new LogEventProperty("Name", new ScalarValue("nblumhardt")),
             })));
+        
+        evt.AddPropertyIfAbsent(new LogEventProperty("@st", new ScalarValue((evt.Timestamp - TimeSpan.FromMinutes(10)).ToString("o"))));
 
         var frFr = CultureInfo.GetCultureInfoByIetfLanguageTag("fr-FR");
         var actual = SerilogExpression.Compile(expr, formatProvider: frFr)(evt);

--- a/test/Seq.Syntax.Tests/Seq.Syntax.Tests.csproj
+++ b/test/Seq.Syntax.Tests/Seq.Syntax.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>


### PR DESCRIPTION
Fixes #8 

Preemptively adds support for tracing-related properties; may need to be revisited after 2024.1 is shipped, but for now I think this is adequate for a "1.0" of this package.