### PR TITLE
Support customizing outgoing emails from third party apps

### DIFF
--- a/src/Seq.Mail/MailApp.cs
+++ b/src/Seq.Mail/MailApp.cs
@@ -83,9 +83,12 @@ public abstract class MailApp : SeqApp, ISubscribeToAsync<LogEvent>
 
     protected abstract Task SendAsync(MimeMessage message, CancellationToken cancel);
 
+    protected virtual void PrepareMessage(LogEvent logEvent, MimeMessage message) { }
+
     public async Task OnAsync(Event<LogEvent> evt)
     {
         using var message = _mailMessageFactory!.FromEvent(evt.Data);
+        PrepareMessage(evt.Data, message);
         await SendAsync(message, default);
     }
         


### PR DESCRIPTION
This adds a new setting to set the Importance header in the email.

Note that this doesn't add support to AmazonSes. It looks like that would have to switch over to `SendRawEmail` (from just `SendEmail`). I don't think that would take much effort since it's already using MimeKit and it would likely only need to use the message's `WriteTo` to write to a new MemoryStream. But then I'd also likely want to bring in Microsoft.IO.RecyclableMemoryStream. If that's acceptable, I can go ahead and do that too.
