### PR TITLE
Dependency updates

### DIFF
--- a/harness/Seq.Mail.TestHarness/Seq.Mail.TestHarness.csproj
+++ b/harness/Seq.Mail.TestHarness/Seq.Mail.TestHarness.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Seq.App.Mail.AmazonSes/Seq.App.Mail.AmazonSes.csproj
+++ b/src/Seq.App.Mail.AmazonSes/Seq.App.Mail.AmazonSes.csproj
@@ -24,7 +24,7 @@
   
   <ItemGroup>
     <PackageReference Include="Seq.Apps" Version="2023.4.0" />
-    <PackageReference Include="AWSSDK.SimpleEmail" Version="3.7.300.83" />
+    <PackageReference Include="AWSSDK.SimpleEmail" Version="3.7.300.106" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Seq.App.Mail.Microsoft365/Seq.App.Mail.Microsoft365.csproj
+++ b/src/Seq.App.Mail.Microsoft365/Seq.App.Mail.Microsoft365.csproj
@@ -24,8 +24,8 @@
   
   <ItemGroup>
     <PackageReference Include="Seq.Apps" Version="2023.4.0" />
-    <PackageReference Include="Azure.Identity" Version="1.11.2" />
-    <PackageReference Include="Microsoft.Graph" Version="5.50.0" />
+    <PackageReference Include="Azure.Identity" Version="1.12.0" />
+    <PackageReference Include="Microsoft.Graph" Version="5.56.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Seq.Apps.Testing/Seq.Apps.Testing.csproj
+++ b/src/Seq.Apps.Testing/Seq.Apps.Testing.csproj
@@ -13,7 +13,7 @@
 
     <ItemGroup>
         <PackageReference Include="Seq.Apps" Version="2023.4.0" />
-        <PackageReference Include="Serilog.Formatting.Compact" Version="2.0.0" />
+        <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
         <PackageReference Include="Serilog.Formatting.Compact.Reader" Version="3.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>

--- a/src/Seq.Mail/Seq.Mail.csproj
+++ b/src/Seq.Mail/Seq.Mail.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="mailkit" Version="4.5.0" />
+    <PackageReference Include="mailkit" Version="4.6.0" />
     <PackageReference Include="Superpower" Version="3.0.0" />
     <PackageReference Include="Seq.Apps" Version="2023.4.0" />
   </ItemGroup>

--- a/src/Seq.Syntax/Seq.Syntax.csproj
+++ b/src/Seq.Syntax/Seq.Syntax.csproj
@@ -20,7 +20,7 @@
     <ItemGroup>
         <None Include="../../asset/seq-syntax.png" Pack="true" Visible="false" PackagePath="" />
         <PackageReference Include="Superpower" Version="3.0.0" />
-        <PackageReference Include="Serilog" Version="3.1.1" />
+        <PackageReference Include="Serilog" Version="4.0.0" />
     </ItemGroup>
     
 </Project>

--- a/test/Seq.Mail.Tests/Seq.Mail.Tests.csproj
+++ b/test/Seq.Mail.Tests/Seq.Mail.Tests.csproj
@@ -5,13 +5,13 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.8.0" />
-    <PackageReference Include="Serilog.Formatting.Compact" Version="2.0.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Seq.App.Mail.Microsoft365\Seq.App.Mail.Microsoft365.csproj" />

--- a/test/Seq.Syntax.Tests/Seq.Syntax.Tests.csproj
+++ b/test/Seq.Syntax.Tests/Seq.Syntax.Tests.csproj
@@ -5,13 +5,13 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="xunit" Version="2.8.0" />
-        <PackageReference Include="Serilog.Formatting.Compact" Version="2.0.0" />
+        <PackageReference Include="xunit" Version="2.8.1" />
+        <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\src\Seq.Syntax\Seq.Syntax.csproj" />


### PR DESCRIPTION
This includes the recently-vulnerable Azure.Identity package (CVE-2024-35255); the attack vector on that one is "Local" so it's unlikely to impact the way the code is used in this package, though worth an update regardless.