### PR TITLE
Support rendering `@m` in templates when the underlying event uses dotted identifiers

### DIFF
--- a/seq-app-mail.sln.DotSettings
+++ b/seq-app-mail.sln.DotSettings
@@ -1,5 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Comparand/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=formattable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=nblumhardt/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=seqcli/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=seqid/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Seq.Syntax/Seq.Syntax.csproj
+++ b/src/Seq.Syntax/Seq.Syntax.csproj
@@ -11,6 +11,7 @@
         <RepositoryUrl>https://github.com/datalust/seq-app-mail</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
@@ -20,7 +21,7 @@
     <ItemGroup>
         <None Include="../../asset/seq-syntax.png" Pack="true" Visible="false" PackagePath="" />
         <PackageReference Include="Superpower" Version="3.0.0" />
-        <PackageReference Include="Serilog" Version="4.0.0" />
+        <PackageReference Include="Serilog" Version="4.2.0" />
     </ItemGroup>
     
 </Project>

--- a/src/Seq.Syntax/Templates/Compilation/CompiledMessageToken.cs
+++ b/src/Seq.Syntax/Templates/Compilation/CompiledMessageToken.cs
@@ -74,16 +74,49 @@ class CompiledMessageToken : CompiledTemplate
             }
         }
     }
-
-    void EvaluateProperty(IReadOnlyDictionary<string, LogEventPropertyValue> properties, PropertyToken pt,
-        TextWriter output)
+    
+    void EvaluateProperty(IReadOnlyDictionary<string, LogEventPropertyValue> properties, PropertyToken pt, TextWriter output)
     {
-        if (!properties.TryGetValue(pt.PropertyName, out var value))
+        var rest = pt.PropertyName.AsSpan();
+        if (!TryGetNextStep(rest, out var name, out rest))
+        {
+            output.Write(pt);
+            return;
+        }
+
+        if (!properties.TryGetValue(name.ToString(), out var value))
         {
             output.Write(pt.ToString());
             return;
         }
+        
+        while (TryGetNextStep(rest, out name, out rest))
+        {
+            if (value is not StructureValue obj)
+            {
+                output.Write(pt);
+                return;
+            }
 
+            var nameString = name.ToString();
+            var found = false;
+            foreach (var property in obj.Properties)
+            {
+                if (property.Name == nameString)
+                {
+                    value = property.Value;
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found)
+            {
+                output.Write(pt);
+                return;
+            }
+        }
+        
         if (pt.Alignment is null)
         {
             EvaluatePropertyUnaligned(value, output, pt.Format);
@@ -158,5 +191,28 @@ class CompiledMessageToken : CompiledTemplate
         }
 
         output.Write(value);
+    }
+    
+    static bool TryGetNextStep(ReadOnlySpan<char> path, out ReadOnlySpan<char> name, out ReadOnlySpan<char> rest)
+    {
+        if (path.Length == 0)
+        {
+            name = [];
+            rest = [];
+            return false;
+        }
+        
+        var i = path.IndexOf('.');
+        if (i == -1)
+        {
+            name = path;
+            rest = [];
+            return true;
+        }
+        
+        name = path[..i];
+        rest = i == name.Length - 1 ? [] : path[(i + 1)..];
+
+        return true;
     }
 }

--- a/test/Seq.Syntax.Tests/Expressions/ExpressionEvaluationTests.cs
+++ b/test/Seq.Syntax.Tests/Expressions/ExpressionEvaluationTests.cs
@@ -5,6 +5,7 @@ using Seq.Syntax.Expressions;
 using Seq.Syntax.Expressions.Runtime;
 using Seq.Syntax.Tests.Support;
 using Serilog.Events;
+using Serilog.Parsing;
 using Xunit;
 
 namespace Seq.Syntax.Tests.Expressions;
@@ -21,11 +22,10 @@ public class ExpressionEvaluationTests
         var evt = Some.InformationEvent();
 
         evt.AddPropertyIfAbsent(
-            new LogEventProperty("User", new StructureValue(new[]
-            {
+            new LogEventProperty("User", new StructureValue([
                 new LogEventProperty("Id", new ScalarValue(42)),
-                new LogEventProperty("Name", new ScalarValue("nblumhardt")),
-            })));
+                new LogEventProperty("Name", new ScalarValue("nblumhardt"))
+            ])));
         
         evt.AddPropertyIfAbsent(new LogEventProperty("@st", new ScalarValue((evt.Timestamp - TimeSpan.FromMinutes(10)).ToString("o"))));
 
@@ -39,7 +39,9 @@ public class ExpressionEvaluationTests
         }
         else
         {
-            Assert.True(Coerce.IsTrue(RuntimeOperators._Internal_Equal(StringComparison.OrdinalIgnoreCase, actual, expected)), $"Expected value: {Display(expected)}{Environment.NewLine}Actual value: {Display(actual)}");
+            Assert.True(
+                Coerce.IsTrue(RuntimeOperators._Internal_Equal(StringComparison.OrdinalIgnoreCase, actual, expected)),
+                $"Expected value: {Display(expected)}{Environment.NewLine}Actual value: {Display(actual)}");
         }
     }
 
@@ -49,5 +51,36 @@ public class ExpressionEvaluationTests
             return "undefined";
 
         return value.ToString();
+    }
+
+    [Fact]
+    public void MessageRenderingSupportsNestedProperties()
+    {
+        // From the point of view of Seq and Seq Syntax, dotted identifiers in property names are paths into
+        // nested objects. This differs from Serilog's interpretation, which is that they are flat names with
+        // embedded dots. When Seq and Serilog are used together, Serilog.Sinks.Seq performs the conversion
+        // from flat names to nested objects, so on the server, apps etc. need message rendering to work with
+        // the nested data representation.
+        
+        var messageTemplate = new MessageTemplateParser().Parse("HTTP {request.method} {request.path}");
+        var properties = new[]
+        {
+            new LogEventProperty("request", new StructureValue([
+                new LogEventProperty("method", new ScalarValue("GET")),
+                new LogEventProperty("path", new ScalarValue("/example"))
+            ]))
+        };
+        
+        var evt = new LogEvent(
+            DateTimeOffset.Now,
+            LogEventLevel.Debug,
+            exception: null,
+            messageTemplate,
+            properties);
+
+        var message = SerilogExpression.Compile("@m")(evt);
+        var messageValue = Assert.IsType<ScalarValue>(message).Value;
+
+        Assert.Equal("HTTP GET /example", messageValue);
     }
 }


### PR DESCRIPTION
From the point of view of Seq and Seq Syntax, dotted identifiers in property names are paths into
nested objects. This differs from Serilog's interpretation, which is that they are flat names with
embedded dots. When Seq and Serilog are used together, Serilog.Sinks.Seq performs the conversion
from flat names to nested objects, so on the server, apps etc. need message rendering to work with
the nested data representation.

Note, this pushes the version of our Serilog dependency forward to 4.2.0, which won't be available on servers running Seq versions before 2025.1. This shouldn't be a big problem, because the 4.0.0 and 4.1.0 versions supply all of the APIs we need, but good to keep this in mind.