### PR TITLE
Improve `Seq.Syntax` templating compatibility with trace spans

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>1.0.1</VersionPrefix>
+        <VersionPrefix>1.1.0</VersionPrefix>
     </PropertyGroup>
 </Project>

--- a/src/Seq.Syntax/BuiltIns/SeqBuiltInPropertyNameResolver.cs
+++ b/src/Seq.Syntax/BuiltIns/SeqBuiltInPropertyNameResolver.cs
@@ -24,8 +24,9 @@ class SeqBuiltInPropertyNameResolver: NameResolver
             "TraceId" or "tr" => "@p['@tr']",
             "SpanId" or "sp" => "@p['@sp']",
             "Resource" or "ra" => "@p['@ra']",
-            "Start" or "st" => "@p['@st']",
+            "Start" or "st" => "_AsDateTimeOffset(@p['@st'])",
             "ParentId" or "ps" => "@p['@ps']",
+            "SpanKind" or "sk" => "@p['@sk']",
             "Scope" or "sa" => "@p['@sa']",
             "Elapsed" => "_Elapsed(@st, @t)",
             "Arrived" or "Document" or "Data" => "undefined()",
@@ -37,7 +38,7 @@ class SeqBuiltInPropertyNameResolver: NameResolver
 
     public override bool TryResolveFunctionName(string name, [NotNullWhen(true)] out MethodInfo? implementation)
     {
-        if (name == nameof(_Elapsed))
+        if (name == nameof(_Elapsed) || name == nameof(_AsDateTimeOffset))
         {
             implementation = typeof(SeqBuiltInPropertyNameResolver).GetMethod(name)!;
             return true;
@@ -51,6 +52,14 @@ class SeqBuiltInPropertyNameResolver: NameResolver
     {
         if (AsDateTimeOffset(from) is {} f && AsDateTimeOffset(to) is {} t)
             return new ScalarValue(t - f);
+
+        return null;
+    }
+
+    public static LogEventPropertyValue? _AsDateTimeOffset(LogEventPropertyValue? value)
+    {
+        if (AsDateTimeOffset(value) is { } dto)
+            return new ScalarValue(dto);
 
         return null;
     }

--- a/src/Seq.Syntax/Expressions/Compilation/Linq/LinqExpressionCompiler.cs
+++ b/src/Seq.Syntax/Expressions/Compilation/Linq/LinqExpressionCompiler.cs
@@ -104,6 +104,10 @@ class LinqExpressionCompiler : SerilogExpressionTransformer<ExpressionBody>
         if (!_nameResolver.TryResolveFunctionName(call.OperatorName, out var m))
             throw new ArgumentException($"The function name `{call.OperatorName}` was not recognized.");
 
+        if (m == null!)
+            throw new InvalidOperationException(
+                $"The name resolver {_nameResolver} failed to return a valid `MethodInfo` for function `{call.OperatorName}`.");
+
         var methodParameters = m.GetParameters()
             .Select(info => (pi: info, optional: info.GetCustomAttribute<OptionalAttribute>() != null))
             .ToList();

--- a/src/Seq.Syntax/Expressions/Operators.cs
+++ b/src/Seq.Syntax/Expressions/Operators.cs
@@ -16,9 +16,7 @@ using System;
 using System.Collections.Generic;
 using Seq.Syntax.Expressions.Ast;
 
-// ReSharper disable UnusedMember.Global
-
-// ReSharper disable InconsistentNaming, MemberCanBePrivate.Global
+// ReSharper disable UnusedMember.Global, InconsistentNaming, MemberCanBePrivate.Global
 
 namespace Seq.Syntax.Expressions;
 
@@ -37,10 +35,13 @@ static class Operators
     public const string OpEndsWith = "EndsWith";
     public const string OpIndexOf = "IndexOf";
     public const string OpIndexOfMatch = "IndexOfMatch";
-    public const string OpIsMatch = "IsMatch";
     public const string OpIsDefined = "IsDefined";
+    public const string OpIsMatch = "IsMatch";
+    public const string OpIsRootSpan = "IsRootSpan";
+    public const string OpIsSpan = "IsSpan";
     public const string OpLastIndexOf = "LastIndexOf";
     public const string OpLength = "Length";
+    public const string OpMilliseconds = "TotalMilliseconds";
     public const string OpNow = "Now";
     public const string OpRound = "Round";
     public const string OpStartsWith = "StartsWith";

--- a/src/Seq.Syntax/Expressions/Operators.cs
+++ b/src/Seq.Syntax/Expressions/Operators.cs
@@ -41,7 +41,6 @@ static class Operators
     public const string OpIsSpan = "IsSpan";
     public const string OpLastIndexOf = "LastIndexOf";
     public const string OpLength = "Length";
-    public const string OpMilliseconds = "TotalMilliseconds";
     public const string OpNow = "Now";
     public const string OpRound = "Round";
     public const string OpStartsWith = "StartsWith";
@@ -50,6 +49,7 @@ static class Operators
     public const string OpToLower = "ToLower";
     public const string OpToUpper = "ToUpper";
     public const string OpToString = "ToString";
+    public const string OpTotalMilliseconds = "TotalMilliseconds";
     public const string OpTypeOf = "TypeOf";
     public const string OpUndefined = "Undefined";
     public const string OpUriEncode = "UriEncode";

--- a/src/Seq.Syntax/Expressions/Runtime/RuntimeOperators.cs
+++ b/src/Seq.Syntax/Expressions/Runtime/RuntimeOperators.cs
@@ -29,6 +29,8 @@ static class RuntimeOperators
     static readonly LogEventPropertyValue ConstantTrue = new ScalarValue(true),
         ConstantFalse = new ScalarValue(false);
 
+    const string SpanStartTimestampPropertyName = "@st", ParentSpanIdPropertyName = "@ps";
+
     internal static LogEventPropertyValue ScalarBoolean(bool value)
     {
         return value ? ConstantTrue : ConstantFalse;
@@ -505,6 +507,10 @@ static class RuntimeOperators
         
         var toString = sv.Value switch
         {
+            bool boolean => boolean ? "true" : "false",
+            DateTimeOffset dto when dto.Offset == TimeSpan.Zero && fmt == null => dto.UtcDateTime.ToString("O"),
+            DateTimeOffset dto when fmt == null => dto.ToString("O"),
+            DateTime dt when fmt == null => dt.ToString("O"),
             LogEventLevel level => LevelRenderer.GetLevelMoniker(level, fmt),
             IFormattable formattable => formattable.ToString(fmt, formatProvider),
             _ => sv.Value.ToString()
@@ -554,6 +560,41 @@ static class RuntimeOperators
     {
         if (Coerce.String(value, out var s))
             return new ScalarValue(Uri.EscapeDataString(s));
+
+        return null;
+    }
+    
+    public static LogEventPropertyValue? IsSpan(LogEvent logEvent)
+    {
+        return new ScalarValue(logEvent is { TraceId: not null, SpanId: not null } &&
+                               logEvent.Properties.ContainsKey(SpanStartTimestampPropertyName));
+    }
+
+    public static LogEventPropertyValue? IsRootSpan(LogEvent logEvent)
+    {
+        return new ScalarValue(logEvent is { TraceId: not null, SpanId: not null } &&
+                               logEvent.Properties.ContainsKey(SpanStartTimestampPropertyName) &&
+                               !logEvent.Properties.ContainsKey(ParentSpanIdPropertyName));
+    }
+
+    public static LogEventPropertyValue? FromUnixEpoch(LogEventPropertyValue? dateTime)
+    {
+        if (dateTime is ScalarValue sv)
+        {
+            if (sv.Value is DateTimeOffset dto)
+                return new ScalarValue(dto.UtcDateTime - DateTime.UnixEpoch);
+
+            if (sv.Value is DateTime dt)
+                return new ScalarValue(dt.ToUniversalTime() - DateTime.UnixEpoch);
+        }
+
+        return null;
+    }
+
+    public static LogEventPropertyValue? TotalMilliseconds(LogEventPropertyValue? timeSpan)
+    {
+        if (timeSpan is ScalarValue { Value: TimeSpan ts })
+            return new ScalarValue(ts.Ticks / (decimal)TimeSpan.TicksPerMillisecond);
 
         return null;
     }

--- a/test/Seq.Syntax.Tests/Cases/app-host-compatibility-case.json
+++ b/test/Seq.Syntax.Tests/Cases/app-host-compatibility-case.json
@@ -1,0 +1,1 @@
+{"@t":"2025-09-30T00:56:42.4868884Z","@mt":"Run demo app","@m":"Run demo app","@i":"6047df22","@tr":"f42777ef7fcfa457aa7126d57da507fe","@sp":"a6c09c6e0fa0d607","@st":"2025-09-30T00:56:41.4493934Z","@sk":"Internal","Application":"Demo"}

--- a/test/Seq.Syntax.Tests/Expressions/AppHostCompatibilityTests.cs
+++ b/test/Seq.Syntax.Tests/Expressions/AppHostCompatibilityTests.cs
@@ -1,0 +1,32 @@
+using System.IO;
+using System.Linq;
+using Seq.Syntax.Templates;
+using Seq.Syntax.Tests.Support;
+using Serilog.Formatting.Compact.Reader;
+using Xunit;
+
+namespace Seq.Syntax.Tests.Expressions;
+
+public class AppHostCompatibilityTests
+{
+    [Theory]
+    [InlineData("TotalMilliseconds(@Elapsed)", "1037.495")]
+    [InlineData("Round(TotalMilliseconds(@Elapsed), 0)", "1037")]
+    [InlineData("IsSpan()", "true")]
+    [InlineData("IsRootSpan()", "true")]
+    [InlineData("@SpanKind", "Internal")]
+    [InlineData("@Start", "2025-09-30T00:56:41.4493934Z")]
+    [InlineData("FromUnixEpoch(@Start)", "20361.00:56:41.4493934")]
+    [InlineData("TotalMilliseconds(FromUnixEpoch(@Start))", "1759193801449.3934")]
+    [InlineData("FromUnixEpoch(@Timestamp)", "20361.00:56:42.4868884")]
+    [InlineData("@EventType", "1615322914")]
+    public void AppHostJsonProcessingIsReasonable(string expression, string expected)
+    {
+        var json = TestCases.ReadNDJsonCases("app-host-compatibility-case.json").Single();
+        var evt = LogEventReader.ReadFromString(json);
+        var template = $"{{ {expression} }}";
+        var output = new StringWriter();
+        new ExpressionTemplate(template).Format(evt, output);
+        Assert.Equal(expected, output.ToString());
+    }
+}

--- a/test/Seq.Syntax.Tests/Expressions/ExpressionEvaluationTests.cs
+++ b/test/Seq.Syntax.Tests/Expressions/ExpressionEvaluationTests.cs
@@ -13,7 +13,7 @@ namespace Seq.Syntax.Tests.Expressions;
 public class ExpressionEvaluationTests
 {
     public static IEnumerable<object[]> ExpressionEvaluationCases =>
-        AsvCases.ReadCases("expression-evaluation-cases.asv");
+        TestCases.ReadAsvCases("expression-evaluation-cases.asv");
 
     [Theory]
     [MemberData(nameof(ExpressionEvaluationCases))]

--- a/test/Seq.Syntax.Tests/Expressions/ExpressionTranslationTests.cs
+++ b/test/Seq.Syntax.Tests/Expressions/ExpressionTranslationTests.cs
@@ -9,7 +9,7 @@ namespace Seq.Syntax.Tests.Expressions;
 public class ExpressionTranslationTests
 {
     public static IEnumerable<object[]> ExpressionEvaluationCases =>
-        AsvCases.ReadCases("translation-cases.asv");
+        TestCases.ReadAsvCases("translation-cases.asv");
 
     [Theory]
     [MemberData(nameof(ExpressionEvaluationCases))]

--- a/test/Seq.Syntax.Tests/Seq.Syntax.Tests.csproj
+++ b/test/Seq.Syntax.Tests/Seq.Syntax.Tests.csproj
@@ -12,12 +12,16 @@
         </PackageReference>
         <PackageReference Include="xunit" Version="2.8.1" />
         <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
+        <PackageReference Include="Serilog.Formatting.Compact.Reader" Version="4.0.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\src\Seq.Syntax\Seq.Syntax.csproj" />
     </ItemGroup>
     <ItemGroup>
         <Content Include="Cases/*.asv">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+        <Content Include="Cases/*.json">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
     </ItemGroup>

--- a/test/Seq.Syntax.Tests/Support/TestCases.cs
+++ b/test/Seq.Syntax.Tests/Support/TestCases.cs
@@ -11,15 +11,22 @@ namespace Seq.Syntax.Tests.Support;
 // or other!).
 //
 // The ASV format informally supports `//` comment lines, as long as they don't contain the arrow character.
-static class AsvCases
+static class TestCases
 {
     static readonly string CasesPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Cases");
 
-    public static IEnumerable<object[]> ReadCases(string filename)
+    public static IEnumerable<object[]> ReadAsvCases(string filename)
     {
         return from line in File.ReadLines(Path.Combine(CasesPath, filename))
             select line.Split("⇶", StringSplitOptions.RemoveEmptyEntries) into cols
             where cols.Length == 2
             select cols.Select(c => c.Trim()).ToArray<object>();
+    }
+
+    public static IEnumerable<string> ReadNDJsonCases(string filename)
+    {
+        return File.ReadLines(Path.Combine(CasesPath, filename))
+            .Where(line => !string.IsNullOrWhiteSpace(line))
+            .Select(line => line.Trim());
     }
 }

--- a/test/Seq.Syntax.Tests/Templates/TemplateEncodingTests.cs
+++ b/test/Seq.Syntax.Tests/Templates/TemplateEncodingTests.cs
@@ -9,7 +9,7 @@ namespace Seq.Syntax.Tests.Templates;
 public class TemplateEncodingTests
 {
     public static IEnumerable<object[]> TemplateEvaluationCases =>
-        AsvCases.ReadCases("template-encoding-cases.asv");
+        TestCases.ReadAsvCases("template-encoding-cases.asv");
 
     [Theory]
     [MemberData(nameof(TemplateEvaluationCases))]

--- a/test/Seq.Syntax.Tests/Templates/TemplateEvaluationTests.cs
+++ b/test/Seq.Syntax.Tests/Templates/TemplateEvaluationTests.cs
@@ -10,7 +10,7 @@ namespace Seq.Syntax.Tests.Templates;
 public class TemplateEvaluationTests
 {
     public static IEnumerable<object[]> TemplateEvaluationCases =>
-        AsvCases.ReadCases("template-evaluation-cases.asv");
+        TestCases.ReadAsvCases("template-evaluation-cases.asv");
 
     [Theory]
     [MemberData(nameof(TemplateEvaluationCases))]

--- a/test/Seq.Syntax.Tests/Templates/TemplateParserTests.cs
+++ b/test/Seq.Syntax.Tests/Templates/TemplateParserTests.cs
@@ -15,8 +15,10 @@ public class TemplateParserTests
     [InlineData("Syntax {+Err}or", "Syntax error (line 1, column 9): unexpected operator `+`, expected expression.")]
     [InlineData("Syntax {1 + 2 and}or", "Syntax error (line 1, column 18): unexpected `}`, expected expression.")]
     [InlineData("Missing {Align,-} digits", "Syntax error (line 1, column 17): unexpected `}`, expected number.")]
-    [InlineData("Non-digit {Align,x} specifier", "Syntax error (line 1, column 18): unexpected identifier `x`, expected alignment and width.")]
-    [InlineData("Empty {Align,} digits", "Syntax error (line 1, column 14): unexpected `}`, expected alignment and width.")]
+    [InlineData("Non-digit {Align,x} specifier",
+        "Syntax error (line 1, column 18): unexpected identifier `x`, expected alignment and width.")]
+    [InlineData("Empty {Align,} digits",
+        "Syntax error (line 1, column 14): unexpected `}`, expected alignment and width.")]
     public void ErrorsAreReported(string input, string error)
     {
         Assert.False(ExpressionTemplate.TryParse(input, null, null, null, out _, out var actual));
@@ -30,27 +32,5 @@ public class TemplateParserTests
         Assert.True(parser.TryParse("{x}", out var template, out _));
         var avt = Assert.IsType<FormattedExpression>(template);
         Assert.Null(avt.Alignment);
-    }
-
-    const string Template =
-"""
-{ {
-operationName: 'CreateLinearIssueFromSeq',
-query: 'mutation CreateLinearIssueFromSeq($input: IssueCreateInput!) { issueCreate(input: $input) {   success  } }',
-variables: {
-  input: {
-    title: @Message,
-    description: 'https://seq.xxxxxxx.io/',
-    teamId: 'xxxxxxxx-5f41-4492-9372-7cf3f699b97b'
-  }
-}
-} }
-""";
-
-    [Fact]
-    public void TemplateCanBeParsed()
-    {
-        var parser = new TemplateParser();
-        Assert.True(parser.TryParse(Template, out _, out var error), error);
     }
 }

--- a/test/Seq.Syntax.Tests/Templates/TemplateParserTests.cs
+++ b/test/Seq.Syntax.Tests/Templates/TemplateParserTests.cs
@@ -31,4 +31,26 @@ public class TemplateParserTests
         var avt = Assert.IsType<FormattedExpression>(template);
         Assert.Null(avt.Alignment);
     }
+
+    const string Template =
+"""
+{ {
+operationName: 'CreateLinearIssueFromSeq',
+query: 'mutation CreateLinearIssueFromSeq($input: IssueCreateInput!) { issueCreate(input: $input) {   success  } }',
+variables: {
+  input: {
+    title: @Message,
+    description: 'https://seq.xxxxxxx.io/',
+    teamId: 'xxxxxxxx-5f41-4492-9372-7cf3f699b97b'
+  }
+}
+} }
+""";
+
+    [Fact]
+    public void TemplateCanBeParsed()
+    {
+        var parser = new TemplateParser();
+        Assert.True(parser.TryParse(Template, out _, out var error), error);
+    }
 }


### PR DESCRIPTION
See: https://github.com/datalust/seq-tickets/discussions/2486

 * Introduces `IsSpan()`, `IsRootSpan()`, `FromUnixEpoch()`, and `TotalMilliseconds()`
 * Adds `@SpanKind`/`@sk` support
 * Changes `@Start`/`@st` to internally use `DateTimeOffset` representation, so that operations on it are identical to the matching `@Timestamp`/`@t` property

We hadn't done anything to nail down `ToString()` representations for datetime types, so I've switched them to ISO-8601 since the default .NET formatting is nondeterministic. Format string placeholders can be used to override this.

Booleans now render as `true` and `false` rather than `True` and `False`.

I don't think these changes warrant a major version bump, so I've gone with a minor.