### PR TITLE
1.1.1 Release

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -14,7 +14,7 @@ if(Test-Path .\artifacts) {
 
 & dotnet restore --no-cache
 
-$dbp = [Xml] (Get-Content .\Directory.Build.props)
+$dbp = [Xml] (Get-Content .\Directory.Version.props)
 $versionPrefix = $dbp.Project.PropertyGroup.VersionPrefix
 
 Write-Output "build: Package version prefix is $versionPrefix"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>1.1.0</VersionPrefix>
+        <VersionPrefix>1.1.1</VersionPrefix>
     </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,8 @@
 <Project>
+    <Import Project="Directory.Version.props" />
+
     <PropertyGroup>
-        <VersionPrefix>1.1.1</VersionPrefix>
+        <Nullable>enable</Nullable>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 </Project>

--- a/Directory.Version.props
+++ b/Directory.Version.props
@@ -1,0 +1,5 @@
+<Project>
+    <PropertyGroup>
+        <VersionPrefix>1.1.1</VersionPrefix>
+    </PropertyGroup>
+</Project>

--- a/harness/Seq.Mail.TestHarness/Seq.Mail.TestHarness.csproj
+++ b/harness/Seq.Mail.TestHarness/Seq.Mail.TestHarness.csproj
@@ -4,7 +4,7 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
+        <CheckEolTargetFramework>false</CheckEolTargetFramework>
     </PropertyGroup>
     
     <ItemGroup>

--- a/seq-app-mail.sln
+++ b/seq-app-mail.sln
@@ -14,7 +14,7 @@ ProjectSection(SolutionItems) = preProject
 	LICENSE = LICENSE
 	README.md = README.md
 	RunLocalSmtp.ps1 = RunLocalSmtp.ps1
-	Directory.Build.props = Directory.Build.props
+	Directory.Version.props = Directory.Version.props
 	Build.ps1 = Build.ps1
 EndProjectSection
 EndProject

--- a/src/Seq.App.Mail.AmazonSes/Seq.App.Mail.AmazonSes.csproj
+++ b/src/Seq.App.Mail.AmazonSes/Seq.App.Mail.AmazonSes.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Nullable>enable</Nullable>
     <Description>Send events and notifications from Seq via the Amazon Simple Email Service (SES) API.</Description>
     <Authors>Datalust, Serilog Contributors</Authors>
     <PackageTags>seq-app amazon aws ses simple email service</PackageTags>
@@ -11,7 +10,6 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/datalust/seq-app-mail</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Seq.App.Mail.Microsoft365/Seq.App.Mail.Microsoft365.csproj
+++ b/src/Seq.App.Mail.Microsoft365/Seq.App.Mail.Microsoft365.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Nullable>enable</Nullable>
     <Description>Send events and notifications from Seq via Microsoft 365 mail.</Description>
     <Authors>Datalust, Serilog Contributors</Authors>
     <PackageTags>seq-app microsoft-365 email</PackageTags>
@@ -11,7 +10,6 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/datalust/seq-app-mail</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Seq.App.Mail.Smtp/Seq.App.Mail.Smtp.csproj
+++ b/src/Seq.App.Mail.Smtp/Seq.App.Mail.Smtp.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Nullable>enable</Nullable>
     <Description>Send events and notifications from Seq via SMTP mail.</Description>
     <Authors>Datalust, Serilog Contributors</Authors>
     <PackageTags>seq-app smtp email</PackageTags>
@@ -11,7 +10,6 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/datalust/seq-app-mail</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Seq.Apps.Testing/Seq.Apps.Testing.csproj
+++ b/src/Seq.Apps.Testing/Seq.Apps.Testing.csproj
@@ -2,9 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <Description>Helper types for development and debugging of Seq plug-in apps.</Description>
         <Authors>Datalust</Authors>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/src/Seq.Mail/Seq.Mail.csproj
+++ b/src/Seq.Mail/Seq.Mail.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Nullable>enable</Nullable>
     <Description>Shared infrastructure for Seq apps that integrate with email and similar messaging services.</Description>
     <Authors>Datalust</Authors>
     <PackageProjectUrl>https://github.com/datalust/seq-app-mail</PackageProjectUrl>
@@ -10,7 +9,6 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/datalust/seq-app-mail</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   
   <ItemGroup>
@@ -22,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="mailkit" Version="4.6.0" />
+    <PackageReference Include="mailkit" Version="4.15.1" />
     <PackageReference Include="Superpower" Version="3.0.0" />
     <PackageReference Include="Seq.Apps" Version="2023.4.0" />
   </ItemGroup>

--- a/src/Seq.Syntax/Seq.Syntax.csproj
+++ b/src/Seq.Syntax/Seq.Syntax.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <Nullable>enable</Nullable>
         <Description>Template and expression evaluation using a syntax based on the Seq query language.</Description>
         <Authors>Datalust</Authors>
         <PackageProjectUrl>https://github.com/datalust/seq-app-mail</PackageProjectUrl>
@@ -10,7 +9,6 @@
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <RepositoryUrl>https://github.com/datalust/seq-app-mail</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
 

--- a/test/Seq.Mail.Tests/Seq.Mail.Tests.csproj
+++ b/test/Seq.Mail.Tests/Seq.Mail.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />

--- a/test/Seq.Mail.Tests/SmtpMailAppTests.cs
+++ b/test/Seq.Mail.Tests/SmtpMailAppTests.cs
@@ -49,7 +49,7 @@ public class SmtpMailAppTests
         Assert.Equal("f@localhost", message.From.ToString());
         Assert.Equal(new[] { "t@localhost", "r@localhost" }, message.To.Select(t => t.ToString()));
         Assert.Equal("s", message.Subject);
-        Assert.Equal("b", message.HtmlBody.Trim());
+        Assert.Equal("b", message.HtmlBody!.Trim());
         Assert.Null(message.TextBody);
     }
 

--- a/test/Seq.Syntax.Tests/Seq.Syntax.Tests.csproj
+++ b/test/Seq.Syntax.Tests/Seq.Syntax.Tests.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <Nullable>enable</Nullable>
-        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />

--- a/test/Seq.Syntax.Tests/Seq.Syntax.Tests.csproj
+++ b/test/Seq.Syntax.Tests/Seq.Syntax.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />


### PR DESCRIPTION
Updates MailKit to v4.15.1 to avoid an upstream CVE when mailing from/to unsanitized addresses.